### PR TITLE
Added scroll bar for modal pages

### DIFF
--- a/client/styles/modal.css
+++ b/client/styles/modal.css
@@ -35,6 +35,9 @@
   flex-direction: column;
   justify-content: center;
   align-items: center;
+  overflow-y: scroll;
+  height: 700px;
+  width: 564px;
 }
 
 .modal-content {


### PR DESCRIPTION
There was an issue with the modal pages. We couldn't see the send button cause of the page's height. So, I added a scroll bar and now it is possible to see send button in a normal view of the browser. 